### PR TITLE
Use `issues` path for PRs.

### DIFF
--- a/main.py
+++ b/main.py
@@ -119,7 +119,7 @@ async def issue(ctx, number: Option(int, "Issue number")):
 @github.command()
 async def pr(ctx, number: Option(int, "Pull request number")):
     """View a pull request from the pycord github repo."""
-    url = f"{repo}/pulls/{number}"
+    url = f"{repo}/issues/{number}"
     view = discord.ui.View()
     view.add_item(discord.ui.Button(label="View Pull Request", url=url))
     await ctx.respond(f"Here's a link", view=view)


### PR DESCRIPTION
PRs are technically just issues and using number in /pr command that is not a PR simply leads to 404 so it would be good to have /pr to use /issues path to not result in 404 even if the number is a issue and not a PR.